### PR TITLE
Class Alias should not be loaded in the service provider

### DIFF
--- a/src/Cyvelnet/Laravel5Fractal/Laravel5FractalServiceProvider.php
+++ b/src/Cyvelnet/Laravel5Fractal/Laravel5FractalServiceProvider.php
@@ -21,15 +21,10 @@ class Laravel5FractalServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-
-        // register our alias
-        class_alias('Cyvelnet\Laravel5Fractal\Facades\Fractal', 'Fractal');
-
         $source_config = __DIR__ . '/../../config/fractal.php';
         $this->publishes([$source_config => 'config/fractal.php'], 'config');
 
         $this->loadViewsFrom(__DIR__ . '/../../views', 'fractal');
-
     }
 
     /**


### PR DESCRIPTION
This causes error in phpunit Tests: `ErrorException: Cannot redeclare class Fractal.`

It should be added in the config/app.php

`'Fractal'  => Cyvelnet\Laravel5Fractal\Facades\Fractal::class,`
