### PR TITLE
Add FractalServices alias of fractal singleton

### DIFF
--- a/src/Cyvelnet/Laravel5Fractal/Laravel5FractalServiceProvider.php
+++ b/src/Cyvelnet/Laravel5Fractal/Laravel5FractalServiceProvider.php
@@ -61,6 +61,7 @@ class Laravel5FractalServiceProvider extends ServiceProvider
 
             return new FractalServices($manager, $app['app']);
         });
+        $this->app->alias('fractal', FractalServices::class);
 
         // register our command here
 


### PR DESCRIPTION
This allows dependency injecting FractalServices using constructor type-hinting instead of using the Fractal façade.
